### PR TITLE
Install `buf` and `protoc` dependencies in CI workflows

### DIFF
--- a/.github/workflows/release-mia.yaml
+++ b/.github/workflows/release-mia.yaml
@@ -22,6 +22,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install buf
+        uses: bufbuild/buf-setup-action@v1
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Build MIA

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -17,5 +17,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install buf
+        uses: bufbuild/buf-setup-action@v1
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test


### PR DESCRIPTION
After #6 we depend on `gevulot-rs` and we need its binary build dependencies to build MIA.

The reason why build errors haven't appeared earlier is because I was disabling testing pipeline when experimenting with releases and forgot to turn it back on.