### PR TITLE
QEMU debug exit support

### DIFF
--- a/mia/Cargo.lock
+++ b/mia/Cargo.lock
@@ -335,6 +335,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const_format"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,10 +843,11 @@ dependencies = [
 [[package]]
 name = "gevulot-rs"
 version = "0.1.0"
-source = "git+https://github.com/gevulotnetwork/gevulot-rs.git?rev=f6657f57771b1c549a83cfe6fc822c3db687707e#f6657f57771b1c549a83cfe6fc822c3db687707e"
+source = "git+https://github.com/gevulotnetwork/gevulot-rs.git?rev=997bd6c5266a98a69253c58b4bd1a35e8d3ec7ae#997bd6c5266a98a69253c58b4bd1a35e8d3ec7ae"
 dependencies = [
  "backon",
  "bip32",
+ "const_format",
  "cosmos-sdk-proto",
  "cosmrs",
  "derivative",
@@ -839,6 +860,7 @@ dependencies = [
  "prost-build",
  "rand",
  "rand_core",
+ "semver",
  "serde",
  "serde_json",
  "tendermint",
@@ -2821,6 +2843,12 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/mia/Cargo.lock
+++ b/mia/Cargo.lock
@@ -1389,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1439,8 +1439,11 @@ version = "0.2.0"
 dependencies = [
  "env_logger 0.11.5",
  "gevulot-rs",
+ "libc",
  "log",
  "nix",
+ "once_cell",
+ "qemu-exit",
  "serde_yaml",
 ]
 
@@ -1774,6 +1777,12 @@ checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
  "prost 0.12.6",
 ]
+
+[[package]]
+name = "qemu-exit"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb0fd6580eeed0103c054e3fba2c2618ff476943762f28a645b63b8692b21c9"
 
 [[package]]
 name = "quote"
@@ -3015,7 +3024,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/mia/Cargo.lock
+++ b/mia/Cargo.lock
@@ -1435,7 +1435,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mia"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "env_logger 0.11.5",
  "gevulot-rs",

--- a/mia/Cargo.toml
+++ b/mia/Cargo.toml
@@ -17,7 +17,7 @@ gevulot-rs = { git = "https://github.com/gevulotnetwork/gevulot-rs.git", rev = "
 env_logger = "0.11.5"
 libc = "0.2"
 log = "0.4.22"
-nix = { version = "0.29", features = ["mount", "reboot"] }
+nix = { version = "0.29", features = ["mount", "reboot", "fs"] }
 once_cell = "1"
 serde_yaml = "0.9.34"
 qemu-exit = "3"

--- a/mia/Cargo.toml
+++ b/mia/Cargo.toml
@@ -15,9 +15,12 @@ path = "src/mia.rs"
 gevulot-rs = { git = "https://github.com/gevulotnetwork/gevulot-rs.git", rev = "997bd6c5266a98a69253c58b4bd1a35e8d3ec7ae" }
 
 env_logger = "0.11.5"
+libc = "0.2"
 log = "0.4.22"
 nix = { version = "0.29", features = ["mount", "reboot"] }
+once_cell = "1"
 serde_yaml = "0.9.34"
+qemu-exit = "3"
 
 [profile.release]
 lto = true

--- a/mia/Cargo.toml
+++ b/mia/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "mia"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [[bin]]

--- a/mia/Cargo.toml
+++ b/mia/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/mia.rs"
 
 [dependencies]
 # TODO: replace rev with tag when possible
-gevulot-rs = { git = "https://github.com/gevulotnetwork/gevulot-rs.git", rev = "f6657f57771b1c549a83cfe6fc822c3db687707e" }
+gevulot-rs = { git = "https://github.com/gevulotnetwork/gevulot-rs.git", rev = "997bd6c5266a98a69253c58b4bd1a35e8d3ec7ae" }
 
 env_logger = "0.11.5"
 log = "0.4.22"

--- a/mia/src/command.rs
+++ b/mia/src/command.rs
@@ -27,7 +27,18 @@ impl Command {
             command.arg(arg);
         }
         let mut child = command.spawn()?;
-        child.wait()?; // Reap the child process to avoid zombie processes
+        let status = child.wait()?; // Reap the child process to avoid zombie processes
+        if !status.success() {
+            return Err(Box::from(format!(
+                "command `{}` failed with code: {}",
+                &self.command,
+                status
+                    .code()
+                    .as_ref()
+                    .map(ToString::to_string)
+                    .unwrap_or("<unknown>".to_string())
+            )));
+        }
         Ok(())
     }
 }

--- a/mia/src/mia.rs
+++ b/mia/src/mia.rs
@@ -43,6 +43,9 @@ fn main() -> ! {
         false
     };
 
+    // Sync filesystems before attempting to shutdown.
+    nix::unistd::sync();
+
     if qemu::QEMU_EXIT_HANDLER.get().is_some() {
         qemu::exit(err);
     }

--- a/mia/src/mia.rs
+++ b/mia/src/mia.rs
@@ -4,13 +4,20 @@ mod command;
 mod logger;
 mod modprobe;
 mod mount;
+mod qemu;
 mod rt_config;
 
 const TARGET: &str = "";
 
-fn shutdown() -> Result<(), Box<dyn std::error::Error>> {
-    nix::sys::reboot::reboot(RebootMode::RB_POWER_OFF)?;
-    Ok(())
+fn shutdown() -> ! {
+    log::info!(target: TARGET, "shutdown");
+    let Err(err) = nix::sys::reboot::reboot(RebootMode::RB_POWER_OFF);
+    log::error!(target: TARGET, "shutdown error: {} ({})", err.desc(), err as i32);
+    // None of the errors from libc::reboot can happened here, because this process must always have
+    // right permissions. So this code can be marked as unreachable.
+    // If an error is encountered, then it's either an error in `nix` or inappropriate use of MIA.
+    // In both of that cases panicing here and causing kernel panic is okay.
+    unreachable!("internal error on poweroff")
 }
 
 const MIA_CONFIG_PATH: &str = "/usr/lib/mia/config.yaml";
@@ -24,17 +31,21 @@ fn start() -> Result<(), Box<dyn std::error::Error>> {
     log::info!(target: TARGET, "run main process");
     cmd.run()?;
 
-    log::info!(target: TARGET, "shutdown");
-    shutdown()?;
-
     Ok(())
 }
 
-fn main() {
-    if let Err(e) = start() {
+// Init process should never return.
+fn main() -> ! {
+    let err = if let Err(e) = start() {
         log::error!(target: TARGET, "{}", e);
+        true
+    } else {
+        false
+    };
+
+    if qemu::QEMU_EXIT_HANDLER.get().is_some() {
+        qemu::exit(err);
     }
-    if let Err(e) = shutdown() {
-        log::error!(target: TARGET, "Shutdown Error: {}", e);
-    }
+    // If no exit handler was set, perform simple shutdown.
+    shutdown()
 }

--- a/mia/src/qemu.rs
+++ b/mia/src/qemu.rs
@@ -1,0 +1,60 @@
+use nix::errno::Errno;
+use once_cell::sync::OnceCell;
+use qemu_exit::{QEMUExit, X86};
+
+const TARGET: &str = "qemu-debug-exit";
+
+/// QEMU exit handler.
+pub static QEMU_EXIT_HANDLER: OnceCell<X86> = OnceCell::new();
+
+/// Setup QEMU exit handler and grant the process permissions to write to debug port `iobase`.
+pub fn setup(
+    iobase: u16,
+    iosize: u64,
+    success_code: u32,
+) -> Result<(), Box<dyn std::error::Error>> {
+    log::info!(target: TARGET, "grant I/O permissions for port 0x{:x}", iobase);
+    let ret = unsafe { libc::ioperm(iobase.into(), iosize, true.into()) };
+    if ret != 0 {
+        return Err(Box::from(format!(
+            "I/O permission for port 0x{:x} failed: {} (code {})",
+            iobase,
+            Errno::from_raw(ret).desc(),
+            ret
+        )));
+    }
+    // Init handler at the end so it won't be available if port permissions failed.
+    log::info!(
+        "setup QEMU exit handler (success code 0x{:x})",
+        success_code
+    );
+    let _ = QEMU_EXIT_HANDLER.get_or_init(|| X86::new(iobase, success_code));
+    Ok(())
+}
+
+fn exit_error() {
+    log::info!(target: TARGET, "exiting QEMU with error");
+    if let Some(handler) = QEMU_EXIT_HANDLER.get() {
+        handler.exit_failure()
+    }
+    log::error!(target: TARGET, "QEMU exit handler is not set");
+}
+
+fn exit_success() {
+    log::info!(target: TARGET, "exiting QEMU with success");
+    if let Some(handler) = QEMU_EXIT_HANDLER.get() {
+        handler.exit_success()
+    }
+    log::error!(target: TARGET, "QEMU exit handler is not set");
+}
+
+/// Try exiting QEMU with debug code.
+/// `error` specifies whether exit with error or with success.
+/// This functions returns only if exiting QEMU failed (exit handler is not set).
+pub fn exit(error: bool) {
+    if error {
+        exit_error()
+    } else {
+        exit_success()
+    }
+}

--- a/mia/src/rt_config.rs
+++ b/mia/src/rt_config.rs
@@ -1,7 +1,8 @@
-use gevulot_rs::runtime_config::RuntimeConfig;
+use gevulot_rs::runtime_config::{DebugExit, RuntimeConfig};
 
 use crate::command::Command;
 use crate::modprobe::Modprobe;
+use crate::qemu;
 
 const TARGET: &str = "rt-config";
 
@@ -19,6 +20,15 @@ pub fn load(mut path: String) -> Result<Command, Box<dyn std::error::Error>> {
         if config.default_mounts && !default_mounts_done {
             crate::mount::default_mounts()?;
             default_mounts_done = true; // avoid re-mounting
+        }
+
+        if let Some(DebugExit::X86 {
+            iobase,
+            iosize,
+            success_code,
+        }) = &config.debug_exit
+        {
+            qemu::setup(*iobase, *iosize as u64, *success_code)?;
         }
 
         for mount in &config.mounts {


### PR DESCRIPTION
This PR implements Debug Exit support in MIA for x86. If MIA gets this setting from configuration, it will try to perform debug exit of QEMU by writing to dedicated port. If it fails for any reason, simple shutdown will be performed as it was before.

Also:
- Fixed catching error of user application. Error code haven't been checked before;
- Added filesystems syncing;
- Some tiny code improvements.

Depends on:

- gevulotnetwork/gevulot-rs/pull/17

After this PR we can create MIA release `0.3.0`.