### PR TITLE
Fix Content-Type check when fetching MIA release

### DIFF
--- a/mia-installer/lib.rs
+++ b/mia-installer/lib.rs
@@ -207,26 +207,19 @@ async fn fetch_mia(tmp: PathBuf, version: String, platform: String) -> Result<Pa
         .ok_or(anyhow!("invalid release tag"))?;
     debug!("using mia-{}", &version);
 
-    let asset_filename = format!("mia-{}-{}", &version, platform);
+    let asset_filename = format!("mia-{}-{}.tar.gz", &version, platform);
     debug!("searching for {} package", &asset_filename);
 
     let asset = release
         .assets
         .iter()
-        .find(|asset| asset.name.starts_with(&asset_filename))
+        .find(|asset| asset.name == asset_filename)
         .ok_or(anyhow!(
             "failed to find MIA package in release mia-{}",
             version
         ))?;
 
-    let asset_dir = match asset.content_type.as_str() {
-        "application/tar+gzip" => {
-            fetch_tar_gz(&tmp, &asset_filename, asset.browser_download_url.clone()).await?
-        }
-        ct => {
-            bail!("unsupported context type for package: {}", ct);
-        }
-    };
+    let asset_dir = fetch_tar_gz(&tmp, &asset_filename, asset.browser_download_url.clone()).await?;
 
     Ok(asset_dir.join(MIA_BIN_NAME))
 }

--- a/mia-installer/lib.rs
+++ b/mia-installer/lib.rs
@@ -162,10 +162,10 @@ pub fn install(config: &InstallConfig) -> Result<()> {
 
 fn get_mia(tmp: &Path, version: &str, platform: &str) -> Result<PathBuf> {
     if let Some(version) = version.strip_prefix("file:") {
-        info!("using mia: {}", &version);
+        info!("using MIA: {}", &version);
         Ok(PathBuf::from(version))
     } else {
-        info!("using mia: {} ({})", &version, &platform);
+        info!("downloading MIA: {} ({})", &version, &platform);
         let tmp = tmp.to_path_buf();
         let version = version.to_string();
         let platform = platform.to_string();
@@ -205,7 +205,7 @@ async fn fetch_mia(tmp: PathBuf, version: String, platform: String) -> Result<Pa
         .tag_name
         .strip_prefix("mia-")
         .ok_or(anyhow!("invalid release tag"))?;
-    debug!("using mia-{}", &version);
+    debug!("resolved release version: mia-{}", &version);
 
     let asset_filename = format!("mia-{}-{}.tar.gz", &version, platform);
     debug!("searching for {} package", &asset_filename);


### PR DESCRIPTION
GitHub was uploading archives with non-standard `application/x-gtar`. Also CLI tool `gh` doesn't allow to specify Content-Type for the asset explicitly. Because of that we don't want to rely on content types of GitHub assets. That's why the check was removed.