### PR TITLE
Fix symlink checking in mia-installer

### DIFF
--- a/mia-installer/lib.rs
+++ b/mia-installer/lib.rs
@@ -281,7 +281,7 @@ fn install_mia_symlink(config: &InstallConfig, as_root: bool) -> Result<()> {
     if full_symlink_path.is_symlink() {
         if config.overwrite_symlink {
             debug!(
-                "symlink {} alreasy exists, removing it",
+                "symlink {} already exists, removing it",
                 config.symlink_path.display()
             );
             run_command(&["rm", full_symlink_path.to_str().unwrap()], as_root)

--- a/mia-installer/lib.rs
+++ b/mia-installer/lib.rs
@@ -278,7 +278,7 @@ fn install_mia_symlink(config: &InstallConfig, as_root: bool) -> Result<()> {
             .context("strip path separator from symlink path")?,
     );
 
-    if full_symlink_path.exists() {
+    if full_symlink_path.is_symlink() {
         if config.overwrite_symlink {
             debug!(
                 "symlink {} alreasy exists, removing it",


### PR DESCRIPTION
Looks like using `std::path::Path::exists()` is bad, because it produces different results on different systems.

`std::path::Path::is_symlink()` should be more solid.