### PR TITLE
Add versions to MIA logs

### DIFF
--- a/mia/src/mia.rs
+++ b/mia/src/mia.rs
@@ -9,6 +9,7 @@ mod qemu;
 mod rt_config;
 
 const TARGET: &str = "";
+const VERSION: Option<&str> = option_env!("CARGO_PKG_VERSION");
 
 fn shutdown() -> ! {
     log::info!(target: TARGET, "shutdown");
@@ -25,7 +26,7 @@ const MIA_CONFIG_PATH: &str = "/usr/lib/mia/config.yaml";
 
 fn start() -> Result<(), Box<dyn std::error::Error>> {
     logger::setup();
-    log::info!(target: TARGET, "start");
+    log::info!(target: TARGET, "MIA version {}", VERSION.unwrap_or("<unknown>"));
 
     let cmd = rt_config::load(MIA_CONFIG_PATH.to_string())?;
 

--- a/mia/src/pre_exit.rs
+++ b/mia/src/pre_exit.rs
@@ -2,17 +2,19 @@ use std::io::{self, Write};
 use std::thread;
 use std::time::Duration;
 
+const TARGET: &str = "pre-exit";
+
 /// Flush stdout and stderr.
 pub fn flush() {
     const FLUSHING_DELAY: Duration = Duration::from_secs(1);
 
     if let Err(err) = io::stdout().flush() {
-        log::error!("flushing stdout: {}", err);
+        log::error!(target: TARGET, "flushing stdout: {}", err);
         let _ = io::stdout().flush();
     }
 
     if let Err(err) = io::stderr().flush() {
-        log::error!("flushing stderr: {}", err);
+        log::error!(target: TARGET, "flushing stderr: {}", err);
         let _ = io::stdout().flush();
     }
 

--- a/mia/src/qemu.rs
+++ b/mia/src/qemu.rs
@@ -25,6 +25,7 @@ pub fn setup(
     }
     // Init handler at the end so it won't be available if port permissions failed.
     log::info!(
+        target: TARGET,
         "setup QEMU exit handler (success code 0x{:x})",
         success_code
     );

--- a/mia/src/rt_config.rs
+++ b/mia/src/rt_config.rs
@@ -1,4 +1,4 @@
-use gevulot_rs::runtime_config::{DebugExit, RuntimeConfig};
+use gevulot_rs::runtime_config::{self, DebugExit, RuntimeConfig};
 
 use crate::command::Command;
 use crate::modprobe::Modprobe;
@@ -10,6 +10,8 @@ pub fn load(mut path: String) -> Result<Command, Box<dyn std::error::Error>> {
     let mut cmd: Option<Command> = None;
     let mut default_mounts_done = false;
     let modprobe = Modprobe::init()?;
+
+    log::info!(target: TARGET, "version {}", runtime_config::VERSION);
 
     loop {
         log::info!(target: TARGET, "loading {}", &path);


### PR DESCRIPTION
This PR adds some versions to logs:

- MIA version is now logged at the beginning
- Runtime config version is now logged before loading

Also fixed tiny bugs.