### PR TITLE
MIA: add /tmp to default mounts

### DIFF
--- a/mia/src/mount.rs
+++ b/mia/src/mount.rs
@@ -176,6 +176,15 @@ pub const DEFAULT_MOUNT_TABLE: &[ConstMount] = &[
             .union(MsFlags::MS_STRICTATIME),
         Some("size=20%,nr_inodes=800k"),
     ),
+    (
+        "tmpfs",
+        "/tmp",
+        "tmpfs",
+        MsFlags::MS_NOSUID
+            .union(MsFlags::MS_NODEV)
+            .union(MsFlags::MS_STRICTATIME),
+        Some("mode=01777,size=50%,nr_inodes=1m"),
+    ),
 ];
 
 /// Mount default filesystems from [`DEFAULT_MOUNT_TABLE`].


### PR DESCRIPTION
> Programs must not assume that any files or directories in `/tmp` are preserved between invocations of the program.

[Reference](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s18.html)

Because of this I think it's fine to add `/tmp` to default MIA mounts.